### PR TITLE
Fixed line breaks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,27 +51,27 @@ MSI DEPLOYMENT
 Be sure that last x86 AND x64 MSVC++ redistribuable are installed.
 If it's not the case, you can deploy them automatically using the four MSI provided in the vc_redist_MSI.zip file
 
-Using Orca, you can create Transform files in order to set the settings of the credential provider.
-The following properties can be set :
-    MULTIOTP_TIMEOUT           Number of seconds to wait for the multiOTP server response. Default value 5.
-    MULTIOTP_CACHE             0|1 1 to enable local cache.
-    MULTIOTP_CPUSCREDUI        run as admin mode (0 or 1 or 2 + e or d for example 1e)
-    MULTIOTP_TIMEOUTCP         Number of seconds to wait for the credentail provider to respond. Default value 60.
-    MULTIOTP_TWO_STEP_HIDE_OTP 0|1 1 to force the credential to request an OTP password in a second step.
-    MULTIOTP_TWO_STEP_SEND_PASSWORD 0|1 1 to enable the credential to request an OTP password by SMS or e-mail.    
-    MULTIOTP_CPUSLOGON         logon mode (0 or 1 or 2 + e or d for example 1e)
-    MULTIOTP_CPUSUNLOCK        unlock mode (0 or 1 or 2 + e or d for example 1e)
-    MULTIOTP_DISPLAYSMSLINK    0|1 1 to enable the sms link on the OTP authentication page.
-	MULTIOTP_DISPLAYEMAILLINK  0|1 1 to enable the e-mail link on the OTP authentication page.
-    MULTIOTP_LOGINTEXT         text displayed underneath the credential logo.
-    MULTIOTP_BITMAP_PATH       The complete path and filename of the bmp image. Size must be 128x128 pixels.
-    MULTIOTP_URL               FQDN of the multiOTP server for example https://192.168.1.188
-    MULTIOTP_SECRET            Secret shared with the smultiOTP server.
-    MULTIOTP_OTP_TEXT          Text displayed in the OTP field.
-    MULTIOTP_OTP_HINT_TEXT     Text displayed when prompted to enter the OTP in the second step.
-    MULTIOTP_OTP_FAIL_TEXT     Text displayed when OTP code is not valid.
-    MULTIOTP_EXCLUDED_ACCOUNT  Specify an account that should be excluded from 2FA. For example contoso\backdoor
-	MULTIOTP_UPNFORMAT         0|1 1 to use UPN format (kevin@test.com instead of kevin) for the username when credential provider calls multiOTP.
+Using Orca, you can create Transform files in order to set the settings of the credential provider.<br>
+The following properties can be set :<br>
+    MULTIOTP_TIMEOUT           Number of seconds to wait for the multiOTP server response. Default value 5.<br>
+    MULTIOTP_CACHE             0|1 1 to enable local cache.<br>
+    MULTIOTP_CPUSCREDUI        run as admin mode (0 or 1 or 2 + e or d for example 1e)<br>
+    MULTIOTP_TIMEOUTCP         Number of seconds to wait for the credentail provider to respond. Default value 60.<br>
+    MULTIOTP_TWO_STEP_HIDE_OTP 0|1 1 to force the credential to request an OTP password in a second step.<br>
+    MULTIOTP_TWO_STEP_SEND_PASSWORD 0|1 1 to enable the credential to request an OTP password by SMS or e-mail.<br>    
+    MULTIOTP_CPUSLOGON         logon mode (0 or 1 or 2 + e or d for example 1e)<br>
+    MULTIOTP_CPUSUNLOCK        unlock mode (0 or 1 or 2 + e or d for example 1e)<br>
+    MULTIOTP_DISPLAYSMSLINK    0|1 1 to enable the sms link on the OTP authentication page.<br>
+    MULTIOTP_DISPLAYEMAILLINK  0|1 1 to enable the e-mail link on the OTP authentication page.<br>
+    MULTIOTP_LOGINTEXT         text displayed underneath the credential logo.<br>
+    MULTIOTP_BITMAP_PATH       The complete path and filename of the bmp image. Size must be 128x128 pixels.<br>
+    MULTIOTP_URL               FQDN of the multiOTP server for example https://192.168.1.188<br>
+    MULTIOTP_SECRET            Secret shared with the smultiOTP server.<br>
+    MULTIOTP_OTP_TEXT          Text displayed in the OTP field.<br>
+    MULTIOTP_OTP_HINT_TEXT     Text displayed when prompted to enter the OTP in the second step.<br>
+    MULTIOTP_OTP_FAIL_TEXT     Text displayed when OTP code is not valid.<br>
+    MULTIOTP_EXCLUDED_ACCOUNT  Specify an account that should be excluded from 2FA. For example contoso\backdoor<br>
+    MULTIOTP_UPNFORMAT         0|1 1 to use UPN format (kevin@test.com instead of kevin) for the username when credential provider calls multiOTP.<br>
 	
 
 Copy the MSI and MST files to a share which is accessible in Read-Execute for every computers
@@ -123,38 +123,38 @@ TECHNICAL DETAILS
   (registry entries have priority over multiotp.ini file entries): HKEY_CLASSES_ROOT\CLSID\{FCEFDFAB-B0A1-4C4D-8B2B-4FF4E0A3D978}
 - the previous registry keys (up to 5.8.1.x) are converted to the new values
 - the available registry keys are
-   cpus_logon                    Logon authentication type [0|1|2|3][e|d]
-                                 0: relevant for remote (RDP) and local operation
-                                 1: relevant for remote operation
-                                 2: relevant for local operation
-                                 3: relevent for remote and local operation - but multiOTP Credential Provider is completely disabled.
-                                 e: Only the multiOTP Credential Provider is available. All other credential providers are not available.
-                                 d: In addition all other credential providers are available.
-                                 Example: cpus_logon = 0e: Only the multiOTP Credential Provider is available for Logon via remote and locally.                                 
+   * cpus_logon                    Logon authentication type [0|1|2|3][e|d]<br>
+                                 0: relevant for remote (RDP) and local operation<br>
+                                 1: relevant for remote operation<br>
+                                 2: relevant for local operation<br>
+                                 3: relevent for remote and local operation - but multiOTP Credential Provider is completely disabled.<br>
+                                 e: Only the multiOTP Credential Provider is available. All other credential providers are not available.<br>
+                                 d: In addition all other credential providers are available.<br>
+                                 Example: cpus_logon = 0e: Only the multiOTP Credential Provider is available for Logon via remote and locally.<br>                                 
                                  
-   cpus_unlock                   Unlock authentication type [0|1|2|3][e|d]
-   cpus_credui                   Authentication in Windows authentication type (when action requires admin rights for example) [0|1|2|3][e|d]
-   excluded_account              Specify an account that should be excluded from 2FA. The format is required to be domain\username or computername\username.
-   login_text                    Specify the text that is displayed underneath the Credential Provider logo and on the right side where available credentials arelisted.
-   multiOTPCacheEnabled          [1|0], used directly by multiOTP
-   multiOTPDefaultPrefix         [Default computer/domain, default is '']. multiOTP use automatically the domain name as default, or computer
+   * cpus_unlock                   Unlock authentication type [0|1|2|3][e|d]
+   * cpus_credui                   Authentication in Windows authentication type (when action requires admin rights for example) [0|1|2|3][e|d]
+   * excluded_account              Specify an account that should be excluded from 2FA. The format is required to be `domain\username` or `computername\username`.
+   * login_text                    Specify the text that is displayed underneath the Credential Provider logo and on the right side where available credentials arelisted.
+   * multiOTPCacheEnabled          [1|0], used directly by multiOTP
+   * multiOTPDefaultPrefix         [Default computer/domain, default is '']. multiOTP use automatically the domain name as default, or computer
                                  name if the computer is not in a domain. You can set here a manual default computer/domain, like for example '.'
-   multiOTPDisplaySmsLink        [0|1]
-   multiOTPDisplayEmailLink      [0|1]
-   multiOTPServers               [multiOTP server(s) to contact, default is 'https://192.168.1.88'], used directly by multiOTP
-   multiOTPServerTimeout         [timeout in seconds before switching to the next server, default is 5], used directly by multiOTP
-   multiOTPSharedSecret          [secret to connect this client to the server, default is 'ClientServerSecret'], used directly by multiOTP
-   multiOTPTimeout               [timeout in seconds, default is 60]
-   multiOTPUPNFormat			 [0|1] Set to 1 to use UPN username (kevin@test.com) instead of username (kevin)
-   two_step_hide_otp             [0|1] Set to 1 if the Credential Provider should ask for the user's OTP in a second step. In the first step the
+   * multiOTPDisplaySmsLink        [0|1]
+   * multiOTPDisplayEmailLink      [0|1]
+   * multiOTPServers               [multiOTP server(s) to contact, default is 'https://192.168.1.88'], used directly by multiOTP
+   * multiOTPServerTimeout         [timeout in seconds before switching to the next server, default is 5], used directly by multiOTP
+   * multiOTPSharedSecret          [secret to connect this client to the server, default is 'ClientServerSecret'], used directly by multiOTP
+   * multiOTPTimeout               [timeout in seconds, default is 60]
+   * multiOTPUPNFormat			 [0|1] Set to 1 to use UPN username (kevin@test.com) instead of username (kevin)
+   * two_step_hide_otp             [0|1] Set to 1 if the Credential Provider should ask for the user's OTP in a second step. In the first step the
                                  user will only be asked for the password.
-   two_step_send_password        [0|1] Set to 1 if the Credential Provider should send the user's password to the multiOTP server
-   two_step_send_empty_password  [0|1] Set to 1 if the Credential Provider should send an empty password to the multiOTP server
-   otp_text                      Speficy the text that is displayed in the OTP input field. Usually this is "One-Time Password", but you can change it
+   * two_step_send_password        [0|1] Set to 1 if the Credential Provider should send the user's password to the multiOTP server
+   * two_step_send_empty_password  [0|1] Set to 1 if the Credential Provider should send an empty password to the multiOTP server
+   * otp_text                      Speficy the text that is displayed in the OTP input field. Usually this is "One-Time Password", but you can change it
                                  to any other value you like.
-   otp_hint_text                 Speficy the text that is displayed when prompted to enter the OTP in the second step.
-   otp_fail_text                 Specify a custom text that is shown when the OTP verification failed.
-   v1_bitmap_path                The complete path and filename of a bitmap image. This is a customized login image. The image must be a version 3
+   * otp_hint_text                 Speficy the text that is displayed when prompted to enter the OTP in the second step.
+   * otp_fail_text                 Specify a custom text that is shown when the OTP verification failed.
+   * v1_bitmap_path                The complete path and filename of a bitmap image. This is a customized login image. The image must be a version 3
                                  Windows BMP file with a resolution of 128x128 pixels.
 
 


### PR DESCRIPTION
Fixed line breaks in the description of MSI parameters and registry keys.

If there is one line break between the lines and there is no `<br>` tag, then in GitHub these lines will be merged into one.
Nested lists have been used to display indentation correctly (Characters `*` and `-` in Markdown markup)