### PR TITLE
Add Windows CI and WPF management client

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,9 +2,6 @@ name: Windows build
 
 on:
   push:
-    branches:
-      - master
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,94 @@
+name: Windows build
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  credential-provider:
+    name: Credential Provider (${{ matrix.artifactName }})
+    runs-on: windows-2022
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: x64
+            artifactName: x64
+          - platform: Win32
+            artifactName: x86
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+
+      - name: Locate MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build solution
+        shell: pwsh
+        run: >
+          msbuild multiOTPCredentialProvider.sln
+          /m
+          /nologo
+          /p:Configuration=${{ env.BUILD_CONFIGURATION }}
+          /p:Platform=${{ matrix.platform }}
+          /p:PlatformToolset=v143
+          /bl:${{ github.workspace }}\msbuild-${{ matrix.artifactName }}.binlog
+
+      - name: Upload ${{ matrix.artifactName }} artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: multiotp-credential-provider-${{ matrix.artifactName }}
+          if-no-files-found: error
+          path: |
+            CredentialProvider/${{ matrix.platform }}/${{ env.BUILD_CONFIGURATION }}/*.dll
+            CredentialProviderFilter/${{ matrix.platform }}/${{ env.BUILD_CONFIGURATION }}/*.dll
+            CppClientCore/CppClientCore/${{ matrix.platform }}/${{ env.BUILD_CONFIGURATION }}/*.lib
+            WixInstall/multiOTPCredentialProviderInstaller/bin/${{ matrix.artifactName }}/${{ env.BUILD_CONFIGURATION }}/*.msi
+            msbuild-${{ matrix.artifactName }}.binlog
+
+  wpf-manager:
+    name: WPF manager
+    runs-on: windows-2022
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+
+      - name: Locate MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Install .NET Framework 4.5.2 Developer Pack
+        shell: pwsh
+        run: choco install netfx-4.5.2-devpack --no-progress -y
+
+      - name: Build manager
+        shell: pwsh
+        run: >
+          msbuild MultiOtpManager/MultiOtpManager.csproj
+          /m
+          /nologo
+          /p:Configuration=${{ env.BUILD_CONFIGURATION }}
+          /p:Platform=AnyCPU
+          /bl:${{ github.workspace }}\msbuild-manager.binlog
+
+      - name: Upload manager artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: multiotp-manager
+          if-no-files-found: error
+          path: |
+            MultiOtpManager/bin/${{ env.BUILD_CONFIGURATION }}/*
+            msbuild-manager.binlog

--- a/MultiOtpManager/App.config
+++ b/MultiOtpManager/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+</configuration>

--- a/MultiOtpManager/App.xaml
+++ b/MultiOtpManager/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="MultiOtpManager.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/MultiOtpManager/App.xaml.cs
+++ b/MultiOtpManager/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace MultiOtpManager
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/MultiOtpManager/Core/CredentialProviderRegistryService.cs
+++ b/MultiOtpManager/Core/CredentialProviderRegistryService.cs
@@ -1,0 +1,127 @@
+using Microsoft.Win32;
+using System;
+
+namespace MultiOtpManager.Core
+{
+    public sealed class CredentialProviderSettings
+    {
+        public string LogonMode { get; set; }
+        public string UnlockMode { get; set; }
+        public bool TwoStepHideOtp { get; set; }
+    }
+
+    public sealed class CredentialProviderRegistryService
+    {
+        private const string RegistryPath = "CLSID\\{FCEFDFAB-B0A1-4C4D-8B2B-4FF4E0A3D978}";
+
+        public CredentialProviderSettings Load()
+        {
+            using (RegistryKey classesRoot = OpenClassesRoot())
+            using (RegistryKey key = classesRoot.OpenSubKey(RegistryPath))
+            {
+                if (key == null)
+                {
+                    return new CredentialProviderSettings
+                    {
+                        LogonMode = "3d",
+                        UnlockMode = "3d",
+                        TwoStepHideOtp = false
+                    };
+                }
+
+                return new CredentialProviderSettings
+                {
+                    LogonMode = ReadString(key, "cpus_logon", "3d"),
+                    UnlockMode = ReadString(key, "cpus_unlock", "3d"),
+                    TwoStepHideOtp = ReadInteger(key, "two_step_hide_otp", 0) != 0
+                };
+            }
+        }
+
+        public void Save(CredentialProviderSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            string logonMode = NormalizeScenario(settings.LogonMode, "3d");
+            string unlockMode = NormalizeScenario(settings.UnlockMode, "3d");
+
+            using (RegistryKey classesRoot = OpenClassesRoot())
+            using (RegistryKey key = classesRoot.CreateSubKey(RegistryPath))
+            {
+                key.SetValue("cpus_logon", logonMode, RegistryValueKind.String);
+                key.SetValue("cpus_unlock", unlockMode, RegistryValueKind.String);
+                key.SetValue("two_step_hide_otp", settings.TwoStepHideOtp ? "1" : "0", RegistryValueKind.String);
+            }
+        }
+
+        private static RegistryKey OpenClassesRoot()
+        {
+            RegistryView view = Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Default;
+            return RegistryKey.OpenBaseKey(RegistryHive.ClassesRoot, view);
+        }
+
+        private static string ReadString(RegistryKey key, string name, string fallback)
+        {
+            object value = key.GetValue(name);
+            if (value == null)
+            {
+                return fallback;
+            }
+
+            string text = Convert.ToString(value);
+            return string.IsNullOrWhiteSpace(text) ? fallback : text;
+        }
+
+        private static int ReadInteger(RegistryKey key, string name, int fallback)
+        {
+            object value = key.GetValue(name);
+            if (value == null)
+            {
+                return fallback;
+            }
+
+            try
+            {
+                return Convert.ToInt32(value);
+            }
+            catch (FormatException)
+            {
+                return fallback;
+            }
+            catch (InvalidCastException)
+            {
+                return fallback;
+            }
+            catch (OverflowException)
+            {
+                return fallback;
+            }
+        }
+
+        private static string NormalizeScenario(string value, string fallback)
+        {
+            string text = (value ?? string.Empty).Trim();
+            if (text.Length == 0)
+            {
+                text = fallback;
+            }
+
+            char scope = text[0];
+            if (scope != '0' && scope != '1' && scope != '2' && scope != '3')
+            {
+                scope = fallback[0];
+            }
+
+            char availability = text.Length > 1 ? char.ToLowerInvariant(text[text.Length - 1]) : 'd';
+            if (availability != 'e' && availability != 'd')
+            {
+                availability = 'd';
+            }
+
+            return string.Concat(scope.ToString(), availability.ToString());
+        }
+    }
+}

--- a/MultiOtpManager/Core/MultiOtpCliClient.cs
+++ b/MultiOtpManager/Core/MultiOtpCliClient.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MultiOtpManager.Core
+{
+    public sealed class MultiOtpCliClient
+    {
+        private readonly MultiOtpProcessExecutor executor;
+
+        public MultiOtpCliClient()
+        {
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string executablePath = Path.Combine(baseDirectory, "multiotp.exe");
+            executor = new MultiOtpProcessExecutor(executablePath);
+        }
+
+        public string ExecutablePath
+        {
+            get { return executor.ExecutablePath; }
+        }
+
+        public bool UseVerifySwitch { get; set; }
+
+        public Task<ProcessRunResult> VerifyAsync(
+            string username,
+            string otp,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            ValidateRequiredText(username, "username");
+            ValidateRequiredText(otp, "OTP");
+
+            List<string> arguments = new List<string>();
+            if (UseVerifySwitch)
+            {
+                arguments.Add("-verify");
+            }
+
+            arguments.Add(username);
+            arguments.Add(otp);
+            return executor.ExecuteAsync(arguments, timeout, cancellationToken);
+        }
+
+        public Task<ProcessRunResult> GetUsersAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            List<string> arguments = new List<string>();
+            arguments.Add("-userslist");
+            return executor.ExecuteAsync(arguments, timeout, cancellationToken);
+        }
+
+        public Task<ProcessRunResult> GetUserAsync(
+            string username,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            ValidateRequiredText(username, "username");
+
+            List<string> arguments = new List<string>();
+            arguments.Add("-user-info");
+            arguments.Add(username);
+            return executor.ExecuteAsync(arguments, timeout, cancellationToken);
+        }
+
+        private static void ValidateRequiredText(string value, string fieldName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException(fieldName + " is required.", fieldName);
+            }
+        }
+    }
+}

--- a/MultiOtpManager/Core/MultiOtpProcessExecutor.cs
+++ b/MultiOtpManager/Core/MultiOtpProcessExecutor.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MultiOtpManager.Core
+{
+    public sealed class ProcessRunResult
+    {
+        public int ExitCode { get; set; }
+        public string StandardOutput { get; set; }
+        public string StandardError { get; set; }
+    }
+
+    public sealed class MultiOtpProcessExecutor
+    {
+        private const int FlushTimeoutMilliseconds = 2000;
+
+        public MultiOtpProcessExecutor(string executablePath)
+        {
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                throw new ArgumentException("The executable path is required.", "executablePath");
+            }
+
+            ExecutablePath = Path.GetFullPath(executablePath);
+        }
+
+        public string ExecutablePath { get; private set; }
+
+        public static string BuildArguments(IEnumerable<string> arguments)
+        {
+            if (arguments == null)
+            {
+                throw new ArgumentNullException("arguments");
+            }
+
+            string[] escapedArguments = arguments
+                .Select(EscapeArgument)
+                .ToArray();
+
+            return string.Join(" ", escapedArguments);
+        }
+
+        public static string EscapeArgument(string argument)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException("argument");
+            }
+
+            if (argument.Length == 0)
+            {
+                return "\"\"";
+            }
+
+            StringBuilder escaped = new StringBuilder(argument.Length + 8);
+            int trailingBackslashes = 0;
+
+            foreach (char character in argument)
+            {
+                if (character == '\\')
+                {
+                    trailingBackslashes++;
+                    continue;
+                }
+
+                if (character == '"')
+                {
+                    escaped.Append('\\', (trailingBackslashes * 2) + 1);
+                    escaped.Append('"');
+                }
+                else
+                {
+                    escaped.Append('\\', trailingBackslashes);
+                    escaped.Append(character);
+                }
+
+                trailingBackslashes = 0;
+            }
+
+            if (trailingBackslashes > 0)
+            {
+                escaped.Append('\\', trailingBackslashes * 2);
+            }
+
+            escaped.Insert(0, '"');
+            escaped.Append('"');
+            return escaped.ToString();
+        }
+
+        public async Task<ProcessRunResult> ExecuteAsync(
+            IList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            if (arguments == null)
+            {
+                throw new ArgumentNullException("arguments");
+            }
+
+            if (!File.Exists(ExecutablePath))
+            {
+                throw new FileNotFoundException("multiotp.exe was not found beside MultiOtpManager.exe.", ExecutablePath);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = ExecutablePath;
+            startInfo.Arguments = BuildArguments(arguments);
+            startInfo.WorkingDirectory = Path.GetDirectoryName(ExecutablePath);
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
+            startInfo.StandardErrorEncoding = Encoding.UTF8;
+
+            using (Process process = new Process())
+            using (CancellationTokenSource timeoutSource = new CancellationTokenSource())
+            using (CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                timeoutSource.Token))
+            {
+                process.StartInfo = startInfo;
+                process.EnableRaisingEvents = true;
+
+                StringBuilder standardOutput = new StringBuilder();
+                StringBuilder standardError = new StringBuilder();
+                object outputLock = new object();
+                TaskCompletionSource<object> exitWaiter = new TaskCompletionSource<object>();
+                bool timedOut = false;
+
+                EventHandler exitedHandler = delegate
+                {
+                    exitWaiter.TrySetResult(null);
+                };
+
+                DataReceivedEventHandler outputHandler = delegate(object sender, DataReceivedEventArgs eventArgs)
+                {
+                    if (eventArgs.Data != null)
+                    {
+                        lock (outputLock)
+                        {
+                            standardOutput.AppendLine(eventArgs.Data);
+                        }
+                    }
+                };
+
+                DataReceivedEventHandler errorHandler = delegate(object sender, DataReceivedEventArgs eventArgs)
+                {
+                    if (eventArgs.Data != null)
+                    {
+                        lock (outputLock)
+                        {
+                            standardError.AppendLine(eventArgs.Data);
+                        }
+                    }
+                };
+
+                process.Exited += exitedHandler;
+                process.OutputDataReceived += outputHandler;
+                process.ErrorDataReceived += errorHandler;
+
+                try
+                {
+                    process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+
+                    if (timeout > TimeSpan.Zero)
+                    {
+                        timeoutSource.CancelAfter(timeout);
+                    }
+
+                    using (CancellationTokenRegistration registration = linkedSource.Token.Register(delegate
+                    {
+                        timedOut = !cancellationToken.IsCancellationRequested;
+                        TryStopProcess(process);
+                        exitWaiter.TrySetCanceled(linkedSource.Token);
+                    }))
+                    {
+                        await exitWaiter.Task.ConfigureAwait(false);
+                    }
+
+                    process.WaitForExit(FlushTimeoutMilliseconds);
+
+                    string output;
+                    string error;
+
+                    lock (outputLock)
+                    {
+                        output = standardOutput.ToString();
+                        error = standardError.ToString();
+                    }
+
+                    return new ProcessRunResult
+                    {
+                        ExitCode = process.ExitCode,
+                        StandardOutput = output,
+                        StandardError = error
+                    };
+                }
+                catch (OperationCanceledException)
+                {
+                    if (timedOut)
+                    {
+                        throw new TimeoutException("The multiOTP command timed out.");
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    process.Exited -= exitedHandler;
+                    process.OutputDataReceived -= outputHandler;
+                    process.ErrorDataReceived -= errorHandler;
+                    TryWaitAfterCancellation(process);
+                }
+            }
+        }
+
+        private static void TryStopProcess(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+            }
+        }
+
+        private static void TryWaitAfterCancellation(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.WaitForExit(FlushTimeoutMilliseconds);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+            }
+        }
+    }
+}

--- a/MultiOtpManager/Core/MultiOtpProcessExecutor.cs
+++ b/MultiOtpManager/Core/MultiOtpProcessExecutor.cs
@@ -182,7 +182,7 @@ namespace MultiOtpManager.Core
                     {
                         timedOut = !cancellationToken.IsCancellationRequested;
                         TryStopProcess(process);
-                        exitWaiter.TrySetCanceled(linkedSource.Token);
+                        exitWaiter.TrySetCanceled();
                     }))
                     {
                         await exitWaiter.Task.ConfigureAwait(false);

--- a/MultiOtpManager/Core/UserModels.cs
+++ b/MultiOtpManager/Core/UserModels.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MultiOtpManager.Core
+{
+    public sealed class UserSummary
+    {
+        public string Name { get; set; }
+        public string TokenType { get; set; }
+        public string Status { get; set; }
+    }
+
+    public sealed class UserDetail
+    {
+        private readonly Dictionary<string, string> values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        public static UserDetail Parse(string text)
+        {
+            UserDetail detail = new UserDetail();
+            if (string.IsNullOrEmpty(text))
+            {
+                return detail;
+            }
+
+            string[] lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string line in lines)
+            {
+                int separatorIndex = line.IndexOf(':');
+                if (separatorIndex <= 0)
+                {
+                    continue;
+                }
+
+                string key = line.Substring(0, separatorIndex).Trim();
+                string value = line.Substring(separatorIndex + 1).Trim();
+                if (key.Length > 0)
+                {
+                    detail.values[key] = value;
+                }
+            }
+
+            return detail;
+        }
+
+        public string Username
+        {
+            get { return GetValue("Information for user", "(unknown)"); }
+        }
+
+        public string TokenType
+        {
+            get { return GetValue("Algorithm", "Not provided"); }
+        }
+
+        public string Created
+        {
+            get { return "Not provided by this CLI version"; }
+        }
+
+        public string Status
+        {
+            get
+            {
+                string activated = GetValue("Activated", "unknown");
+                string locked = GetValue("Locked", "no");
+                string delayed = GetValue("Delayed", "no");
+
+                List<string> states = new List<string>();
+                states.Add(StringComparer.OrdinalIgnoreCase.Equals(activated, "yes") ? "Activated" : "Disabled");
+
+                if (StringComparer.OrdinalIgnoreCase.Equals(locked, "yes"))
+                {
+                    states.Add("Locked");
+                }
+
+                if (StringComparer.OrdinalIgnoreCase.Equals(delayed, "yes"))
+                {
+                    states.Add("Delayed");
+                }
+
+                return string.Join(", ", states.ToArray());
+            }
+        }
+
+        public string OtpDigits
+        {
+            get { return GetValue("OTP digits", "Not provided"); }
+        }
+
+        public string Description
+        {
+            get { return GetValue("Description", string.Empty); }
+        }
+
+        public string Email
+        {
+            get { return GetValue("Email", string.Empty); }
+        }
+
+        public string MobilePhone
+        {
+            get { return GetValue("Mobile phone", string.Empty); }
+        }
+
+        public string ToMaskedDisplayText()
+        {
+            IEnumerable<string> lines = values
+                .OrderBy(delegate(KeyValuePair<string, string> item) { return item.Key; })
+                .Select(delegate(KeyValuePair<string, string> item)
+                {
+                    if (IsSensitiveKey(item.Key))
+                    {
+                        return item.Key + ": ********";
+                    }
+
+                    return item.Key + ": " + item.Value;
+                });
+
+            return string.Join(Environment.NewLine, lines.ToArray());
+        }
+
+        private string GetValue(string key, string fallback)
+        {
+            string value;
+            return values.TryGetValue(key, out value) && !string.IsNullOrWhiteSpace(value) ? value : fallback;
+        }
+
+        private static bool IsSensitiveKey(string key)
+        {
+            string lowerCaseKey = key.ToLowerInvariant();
+            return lowerCaseKey.Contains("seed") ||
+                   lowerCaseKey.Contains("secret") ||
+                   lowerCaseKey.Contains("password") ||
+                   lowerCaseKey.Contains("pin");
+        }
+    }
+}

--- a/MultiOtpManager/MainWindow.xaml
+++ b/MultiOtpManager/MainWindow.xaml
@@ -1,0 +1,465 @@
+<Window x:Class="MultiOtpManager.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="multiOTP Manager"
+        Width="1040"
+        Height="680"
+        MinWidth="880"
+        MinHeight="560"
+        WindowStartupLocation="CenterScreen"
+        TextOptions.TextFormattingMode="Display"
+        UseLayoutRounding="True"
+        Closed="Window_Closed"
+        Loaded="Window_Loaded">
+    <Window.Resources>
+        <SolidColorBrush x:Key="WindowBackground" Color="#F3F5F7" />
+        <SolidColorBrush x:Key="PanelBackground" Color="#FFFFFF" />
+        <SolidColorBrush x:Key="PanelBorder" Color="#D5DBE1" />
+        <SolidColorBrush x:Key="TextColor" Color="#223038" />
+        <SolidColorBrush x:Key="MutedTextColor" Color="#61707B" />
+        <SolidColorBrush x:Key="AccentColor" Color="#236C72" />
+        <SolidColorBrush x:Key="AccentMouseOverColor" Color="#2C858C" />
+        <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#E7EBEF" />
+        <SolidColorBrush x:Key="SecondaryMouseOverColor" Color="#D8DEE4" />
+        <SolidColorBrush x:Key="GoodColor" Color="#1D6D38" />
+        <SolidColorBrush x:Key="BadColor" Color="#A33131" />
+
+        <Style TargetType="Button">
+            <Setter Property="MinWidth" Value="92" />
+            <Setter Property="Height" Value="30" />
+            <Setter Property="Padding" Value="14,0" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="{StaticResource SecondaryBackgroundColor}" />
+            <Setter Property="BorderBrush" Value="#B8C0C8" />
+            <Setter Property="Foreground" Value="{StaticResource TextColor}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ButtonBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Margin="{TemplateBinding Padding}"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ButtonBorder" Property="Background"
+                                        Value="{StaticResource SecondaryMouseOverColor}" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ButtonBorder" Property="Background" Value="#EDF0F2" />
+                                <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#D5DBE1" />
+                                <Setter Property="Foreground" Value="#98A3AB" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="Background" Value="{StaticResource AccentColor}" />
+            <Setter Property="BorderBrush" Value="#1B575C" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="ButtonBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Margin="{TemplateBinding Padding}"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ButtonBorder" Property="Background"
+                                        Value="{StaticResource AccentMouseOverColor}" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ButtonBorder" Property="Background" Value="#9DB7BA" />
+                                <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="#8CAAAE" />
+                                <Setter Property="Foreground" Value="#E7F1F2" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="7,3" />
+            <Setter Property="BorderBrush" Value="#B8C0C8" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+
+        <Style TargetType="PasswordBox">
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="7,3" />
+            <Setter Property="BorderBrush" Value="#B8C0C8" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+
+        <Style TargetType="ComboBox">
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Padding" Value="7,3" />
+            <Setter Property="BorderBrush" Value="#B8C0C8" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+
+        <Style TargetType="Label">
+            <Setter Property="Foreground" Value="{StaticResource TextColor}" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+
+        <Style x:Key="Panel" TargetType="Border">
+            <Setter Property="Background" Value="{StaticResource PanelBackground}" />
+            <Setter Property="BorderBrush" Value="{StaticResource PanelBorder}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Padding" Value="16" />
+        </Style>
+
+        <Style x:Key="SectionTitle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource TextColor}" />
+        </Style>
+
+        <Style x:Key="FieldCaption" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Foreground" Value="{StaticResource MutedTextColor}" />
+            <Setter Property="Margin" Value="0,0,0,3" />
+        </Style>
+
+        <Style x:Key="FieldValue" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource TextColor}" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
+    </Window.Resources>
+
+    <DockPanel Background="{StaticResource WindowBackground}">
+        <Border DockPanel.Dock="Top" Background="#FFFFFF" BorderBrush="#D5DBE1" BorderThickness="0,0,0,1" Padding="20,13,20,13">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <Border Width="30" Height="30" Background="{StaticResource AccentColor}" CornerRadius="3">
+                        <TextBlock Text="mO"
+                                   Foreground="White"
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center" />
+                    </Border>
+                    <TextBlock Text="multiOTP Manager"
+                               FontSize="19"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource TextColor}"
+                               Margin="10,0,0,0"
+                               VerticalAlignment="Center" />
+                </StackPanel>
+                <TextBlock Grid.Column="1"
+                           x:Name="ExecutablePathText"
+                           Text="multiotp.exe"
+                           Foreground="{StaticResource MutedTextColor}"
+                           VerticalAlignment="Center"
+                           TextTrimming="CharacterEllipsis"
+                           Margin="20,0,20,0"
+                           ToolTip="multiotp.exe location" />
+                <Button Grid.Column="2"
+                        x:Name="CancelButton"
+                        Content="Cancel"
+                        Width="82"
+                        Click="CancelButton_Click"
+                        IsEnabled="False" />
+            </Grid>
+        </Border>
+
+        <Border DockPanel.Dock="Bottom" Background="#FFFFFF" BorderBrush="#D5DBE1" BorderThickness="0,1,0,0" Padding="20,7,20,7">
+            <TextBlock x:Name="StatusText"
+                       Text="Ready"
+                       Foreground="{StaticResource MutedTextColor}"
+                       TextTrimming="CharacterEllipsis" />
+        </Border>
+
+        <TabControl Margin="16" BorderThickness="0" Background="Transparent">
+            <TabItem Header="Authentication">
+                <Grid Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="340" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Style="{StaticResource Panel}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="Authentication test" Style="{StaticResource SectionTitle}" Margin="0,0,0,18" />
+                            <StackPanel Grid.Row="1" Margin="0,0,0,12">
+                                <TextBlock Text="USERNAME" Style="{StaticResource FieldCaption}" />
+                                <TextBox x:Name="UsernameBox" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="2" Margin="0,0,0,12">
+                                <TextBlock Text="OTP" Style="{StaticResource FieldCaption}" />
+                                <PasswordBox x:Name="OtpBox" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,0,0,16">
+                                <Button x:Name="VerifyButton"
+                                        Style="{StaticResource PrimaryButton}"
+                                        Content="Verify"
+                                        Width="104"
+                                        Click="VerifyButton_Click" />
+                            </StackPanel>
+                            <StackPanel Grid.Row="4" VerticalAlignment="Bottom">
+                                <TextBlock Text="TIMEOUT (SECONDS)" Style="{StaticResource FieldCaption}" />
+                                <TextBox x:Name="TimeoutBox" Text="5" />
+                                <CheckBox x:Name="UseVerifySwitchBox"
+                                          Content="Use -verify command"
+                                          Margin="0,10,0,0"
+                                          Foreground="{StaticResource TextColor}"
+                                          ToolTip="Use this only with a multiOTP CLI build that supports -verify." />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Column="1" Style="{StaticResource Panel}" Margin="14,0,0,0">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="Result" Style="{StaticResource SectionTitle}" Margin="0,0,0,12" />
+                            <Border Grid.Row="1"
+                                    Background="#F7F9FA"
+                                    BorderBrush="{StaticResource PanelBorder}"
+                                    BorderThickness="1"
+                                    CornerRadius="3"
+                                    Padding="12,9"
+                                    Margin="0,0,0,12">
+                                <TextBlock x:Name="VerifyResultText"
+                                           Text="No test run"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           Foreground="{StaticResource MutedTextColor}"
+                                           TextWrapping="Wrap" />
+                            </Border>
+                            <TextBox Grid.Row="2"
+                                     x:Name="VerifyOutputBox"
+                                     IsReadOnly="True"
+                                     TextWrapping="Wrap"
+                                     AcceptsReturn="True"
+                                     VerticalScrollBarVisibility="Auto"
+                                     FontFamily="Consolas"
+                                     FontSize="12" />
+                        </Grid>
+                    </Border>
+                </Grid>
+            </TabItem>
+
+            <TabItem Header="Users">
+                <Grid Margin="0,14,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="290" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Style="{StaticResource Panel}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Text="Users" Style="{StaticResource SectionTitle}" Margin="0,0,0,12" />
+                            <Button Grid.Row="1"
+                                    x:Name="RefreshUsersButton"
+                                    Style="{StaticResource PrimaryButton}"
+                                    Content="Refresh"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,0,0,12"
+                                    Click="RefreshUsersButton_Click" />
+                            <ListBox Grid.Row="2"
+                                     x:Name="UsersListBox"
+                                     SelectionChanged="UsersListBox_SelectionChanged"
+                                     BorderBrush="{StaticResource PanelBorder}"
+                                     Background="White"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,7">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{StaticResource TextColor}"
+                                                       TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Foreground="{StaticResource MutedTextColor}"
+                                                       FontSize="11"
+                                                       TextTrimming="CharacterEllipsis">
+                                                <Run Text="{Binding TokenType}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding Status}" />
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Column="1" Style="{StaticResource Panel}" Margin="14,0,0,0">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid Grid.Row="0" Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,14,13">
+                                    <TextBlock Text="USERNAME" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailUsernameText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Grid.Row="0" Margin="0,0,14,13">
+                                    <TextBlock Text="TOKEN TYPE" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailTokenTypeText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Grid.Row="0" Margin="0,0,0,13">
+                                    <TextBlock Text="STATUS" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailStatusText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,14,13">
+                                    <TextBlock Text="CREATED" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailCreatedText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Grid.Row="1" Margin="0,0,14,13">
+                                    <TextBlock Text="OTP DIGITS" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailDigitsText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Grid.Row="1" Margin="0,0,0,13">
+                                    <TextBlock Text="DESCRIPTION" Style="{StaticResource FieldCaption}" />
+                                    <TextBlock x:Name="DetailDescriptionText" Text="-" Style="{StaticResource FieldValue}" />
+                                </StackPanel>
+                            </Grid>
+                            <TextBlock Grid.Row="1" Text="Details" Style="{StaticResource SectionTitle}" Margin="0,0,0,10" />
+                            <TextBox Grid.Row="2"
+                                     x:Name="UserDetailBox"
+                                     IsReadOnly="True"
+                                     TextWrapping="Wrap"
+                                     AcceptsReturn="True"
+                                     VerticalScrollBarVisibility="Auto"
+                                     FontFamily="Consolas"
+                                     FontSize="12" />
+                        </Grid>
+                    </Border>
+                </Grid>
+            </TabItem>
+
+            <TabItem Header="Credential Provider">
+                <Grid Margin="0,14,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Border Grid.Row="0" Style="{StaticResource Panel}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,16,13">
+                                <TextBlock Text="LOGON SCOPE" Style="{StaticResource FieldCaption}" />
+                                <ComboBox x:Name="LogonScopeBox" SelectedValuePath="Tag">
+                                    <ComboBoxItem Content="Local and remote" Tag="0" />
+                                    <ComboBoxItem Content="Remote desktop only" Tag="1" />
+                                    <ComboBoxItem Content="Local only" Tag="2" />
+                                    <ComboBoxItem Content="Disabled" Tag="3" />
+                                </ComboBox>
+                            </StackPanel>
+                            <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,16,0">
+                                <TextBlock Text="LOGON PROVIDERS" Style="{StaticResource FieldCaption}" />
+                                <ComboBox x:Name="LogonExclusiveBox" SelectedValuePath="Tag">
+                                    <ComboBoxItem Content="multiOTP only" Tag="e" />
+                                    <ComboBoxItem Content="Other providers allowed" Tag="d" />
+                                </ComboBox>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Grid.Row="0" Margin="0,0,16,13">
+                                <TextBlock Text="UNLOCK SCOPE" Style="{StaticResource FieldCaption}" />
+                                <ComboBox x:Name="UnlockScopeBox" SelectedValuePath="Tag">
+                                    <ComboBoxItem Content="Local and remote" Tag="0" />
+                                    <ComboBoxItem Content="Remote desktop only" Tag="1" />
+                                    <ComboBoxItem Content="Local only" Tag="2" />
+                                    <ComboBoxItem Content="Disabled" Tag="3" />
+                                </ComboBox>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Grid.Row="1">
+                                <TextBlock Text="UNLOCK PROVIDERS" Style="{StaticResource FieldCaption}" />
+                                <ComboBox x:Name="UnlockExclusiveBox" SelectedValuePath="Tag">
+                                    <ComboBoxItem Content="multiOTP only" Tag="e" />
+                                    <ComboBoxItem Content="Other providers allowed" Tag="d" />
+                                </ComboBox>
+                            </StackPanel>
+                            <Button Grid.Column="2"
+                                    Grid.Row="1"
+                                    x:Name="SaveSettingsButton"
+                                    Style="{StaticResource PrimaryButton}"
+                                    Content="Save"
+                                    VerticalAlignment="Bottom"
+                                    Click="SaveSettingsButton_Click" />
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="1" Style="{StaticResource Panel}" Margin="0,14,0,0">
+                        <StackPanel>
+                            <TextBlock Text="Authentication flow" Style="{StaticResource SectionTitle}" Margin="0,0,0,14" />
+                            <CheckBox x:Name="TwoStepHideOtpBox"
+                                      Content="Ask for OTP in a second step"
+                                      FontSize="13"
+                                      Foreground="{StaticResource TextColor}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
+</Window>

--- a/MultiOtpManager/MainWindow.xaml.cs
+++ b/MultiOtpManager/MainWindow.xaml.cs
@@ -1,0 +1,427 @@
+using MultiOtpManager.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MultiOtpManager
+{
+    public partial class MainWindow
+    {
+        private readonly MultiOtpCliClient cliClient;
+        private readonly CredentialProviderRegistryService registryService;
+        private CancellationTokenSource currentOperationCancellation;
+        private bool refreshingUsers;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            cliClient = new MultiOtpCliClient();
+            registryService = new CredentialProviderRegistryService();
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            ExecutablePathText.Text = cliClient.ExecutablePath;
+            ExecutablePathText.ToolTip = cliClient.ExecutablePath;
+            LoadSettings();
+        }
+
+        private async void VerifyButton_Click(object sender, RoutedEventArgs e)
+        {
+            string username = UsernameBox.Text.Trim();
+            string otp = OtpBox.Password;
+            cliClient.UseVerifySwitch = UseVerifySwitchBox.IsChecked == true;
+
+            try
+            {
+                ProcessRunResult result = await RunOperationAsync(
+                    "verify authentication",
+                    delegate(CancellationToken token)
+                    {
+                        return cliClient.VerifyAsync(username, otp, GetTimeout(), token);
+                    });
+
+                ShowVerifyResult(result);
+            }
+            catch (ArgumentException error)
+            {
+                ShowVerifyFailure(error.Message);
+            }
+            catch (Exception error)
+            {
+                ShowVerifyFailure(GetSafeExceptionMessage(error));
+            }
+            finally
+            {
+                OtpBox.Password = string.Empty;
+            }
+        }
+
+        private async void RefreshUsersButton_Click(object sender, RoutedEventArgs e)
+        {
+            refreshingUsers = true;
+            UsersListBox.SelectedItem = null;
+            ClearUserDetail();
+
+            try
+            {
+                ProcessRunResult result = await RunOperationAsync(
+                    "load users",
+                    delegate(CancellationToken token)
+                    {
+                        return cliClient.GetUsersAsync(GetTimeout(), token);
+                    });
+
+                if (result.ExitCode != 0 && result.ExitCode != 19)
+                {
+                    UserDetailBox.Text = BuildCombinedOutput(result);
+                    SetStatus("User list command failed. Exit code: " + result.ExitCode);
+                    return;
+                }
+
+                List<string> users = result.StandardOutput
+                    .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(delegate(string line) { return line.Trim(); })
+                    .Where(delegate(string line) { return line.Length > 0; })
+                    .ToList();
+
+                UsersListBox.ItemsSource = users
+                    .Select(delegate(string user) { return new UserSummary { Name = user }; })
+                    .ToList();
+
+                if (UsersListBox.Items.Count == 0)
+                {
+                    UserDetailBox.Text = "No users were returned.";
+                }
+
+                SetStatus(users.Count.ToString() + " user(s) loaded.");
+            }
+            catch (Exception error)
+            {
+                SetStatus(GetSafeExceptionMessage(error));
+            }
+            finally
+            {
+                refreshingUsers = false;
+            }
+        }
+
+        private async void UsersListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (refreshingUsers)
+            {
+                return;
+            }
+
+            UserSummary summary = UsersListBox.SelectedItem as UserSummary;
+            if (summary == null)
+            {
+                ClearUserDetail();
+                return;
+            }
+
+            try
+            {
+                ProcessRunResult result = await RunOperationAsync(
+                    "load user details",
+                    delegate(CancellationToken token)
+                    {
+                        return cliClient.GetUserAsync(summary.Name, GetTimeout(), token);
+                    });
+
+                if (result.ExitCode != 0 && result.ExitCode != 19)
+                {
+                    ClearUserDetail();
+                    UserDetailBox.Text = BuildCombinedOutput(result);
+                    SetStatus("User detail command failed. Exit code: " + result.ExitCode);
+                    return;
+                }
+
+                UserDetail detail = UserDetail.Parse(result.StandardOutput);
+                summary.TokenType = detail.TokenType;
+                summary.Status = detail.Status;
+                DetailUsernameText.Text = detail.Username;
+                DetailTokenTypeText.Text = detail.TokenType;
+                DetailStatusText.Text = detail.Status;
+                DetailCreatedText.Text = detail.Created;
+                DetailDigitsText.Text = detail.OtpDigits;
+                DetailDescriptionText.Text = detail.Description;
+                UserDetailBox.Text = detail.ToMaskedDisplayText();
+                SetStatus("Details loaded for " + summary.Name + ".");
+            }
+            catch (Exception error)
+            {
+                ClearUserDetail();
+                SetStatus(GetSafeExceptionMessage(error));
+            }
+        }
+
+        private void SaveSettingsButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                CredentialProviderSettings settings = new CredentialProviderSettings();
+                settings.LogonMode = CombineScenario(LogonScopeBox, LogonExclusiveBox);
+                settings.UnlockMode = CombineScenario(UnlockScopeBox, UnlockExclusiveBox);
+                settings.TwoStepHideOtp = TwoStepHideOtpBox.IsChecked == true;
+
+                registryService.Save(settings);
+                LoadSettings();
+                SetStatus("Credential Provider settings saved.");
+            }
+            catch (Exception error)
+            {
+                MessageBox.Show(
+                    GetSafeExceptionMessage(error),
+                    "Settings not saved",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                SetStatus("Settings were not saved.");
+            }
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            CancellationTokenSource source = currentOperationCancellation;
+            if (source != null)
+            {
+                source.Cancel();
+                SetStatus("Canceling current operation...");
+            }
+        }
+
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            if (currentOperationCancellation != null)
+            {
+                currentOperationCancellation.Cancel();
+            }
+        }
+
+        private async Task<ProcessRunResult> RunOperationAsync(
+            string operationName,
+            Func<CancellationToken, Task<ProcessRunResult>> operation)
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            currentOperationCancellation = source;
+
+            try
+            {
+                SetBusy(true, operationName + "...");
+                return await operation(source.Token);
+            }
+            finally
+            {
+                source.Dispose();
+                currentOperationCancellation = null;
+                SetBusy(false, "Ready");
+            }
+        }
+
+        private void ShowVerifyResult(ProcessRunResult result)
+        {
+            string safeOutput = BuildCombinedOutput(result);
+            VerifyOutputBox.Text = safeOutput;
+
+            if (result.ExitCode == 0)
+            {
+                VerifyResultText.Foreground = FindResource("GoodColor") as System.Windows.Media.Brush;
+                VerifyResultText.Text = "Authentication accepted.";
+                SetStatus("Authentication accepted.");
+                return;
+            }
+
+            VerifyResultText.Foreground = FindResource("BadColor") as System.Windows.Media.Brush;
+            VerifyResultText.Text = "Authentication refused. " + GetFriendlyExitText(result.ExitCode);
+            SetStatus("Authentication refused. Exit code: " + result.ExitCode);
+        }
+
+        private void ShowVerifyFailure(string message)
+        {
+            VerifyResultText.Foreground = FindResource("BadColor") as System.Windows.Media.Brush;
+            VerifyResultText.Text = message;
+            SetStatus(message);
+        }
+
+        private void ClearUserDetail()
+        {
+            DetailUsernameText.Text = "-";
+            DetailTokenTypeText.Text = "-";
+            DetailStatusText.Text = "-";
+            DetailCreatedText.Text = "-";
+            DetailDigitsText.Text = "-";
+            DetailDescriptionText.Text = "-";
+            UserDetailBox.Text = string.Empty;
+        }
+
+        private void LoadSettings()
+        {
+            CredentialProviderSettings settings = registryService.Load();
+            string logonMode = settings.LogonMode ?? "3d";
+            string unlockMode = settings.UnlockMode ?? "3d";
+
+            LogonScopeBox.SelectedValue = logonMode.Substring(0, 1);
+            UnlockScopeBox.SelectedValue = unlockMode.Substring(0, 1);
+            LogonExclusiveBox.SelectedValue = logonMode.Length > 1 ? logonMode.Substring(1) : "d";
+            UnlockExclusiveBox.SelectedValue = unlockMode.Length > 1 ? unlockMode.Substring(1) : "d";
+            TwoStepHideOtpBox.IsChecked = settings.TwoStepHideOtp;
+        }
+
+        private string CombineScenario(ComboBox scopeBox, ComboBox providerBox)
+        {
+            string scope = Convert.ToString(scopeBox.SelectedValue);
+            string provider = Convert.ToString(providerBox.SelectedValue);
+
+            if (string.IsNullOrEmpty(scope))
+            {
+                scope = "0";
+            }
+
+            if (string.IsNullOrEmpty(provider))
+            {
+                provider = "d";
+            }
+
+            return scope + provider;
+        }
+
+        private TimeSpan GetTimeout()
+        {
+            int seconds;
+            if (!int.TryParse(TimeoutBox.Text.Trim(), out seconds))
+            {
+                seconds = 5;
+            }
+
+            if (seconds < 1)
+            {
+                seconds = 1;
+            }
+            else if (seconds > 300)
+            {
+                seconds = 300;
+            }
+
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        private void SetBusy(bool busy, string status)
+        {
+            VerifyButton.IsEnabled = !busy;
+            RefreshUsersButton.IsEnabled = !busy;
+            SaveSettingsButton.IsEnabled = !busy;
+            UsersListBox.IsEnabled = !busy;
+            CancelButton.IsEnabled = busy;
+            SetStatus(status);
+        }
+
+        private void SetStatus(string status)
+        {
+            StatusText.Text = status;
+        }
+
+        private static string BuildCombinedOutput(ProcessRunResult result)
+        {
+            List<string> sections = new List<string>();
+            sections.Add("Exit code: " + result.ExitCode);
+
+            if (!string.IsNullOrWhiteSpace(result.StandardOutput))
+            {
+                sections.Add("Standard output:");
+                sections.Add(MaskSensitiveText(result.StandardOutput.Trim()));
+            }
+
+            if (!string.IsNullOrWhiteSpace(result.StandardError))
+            {
+                sections.Add("Standard error:");
+                sections.Add(MaskSensitiveText(result.StandardError.Trim()));
+            }
+
+            return string.Join(Environment.NewLine + Environment.NewLine, sections.ToArray());
+        }
+
+        private static string MaskSensitiveText(string text)
+        {
+            string[] lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            for (int index = 0; index < lines.Length; index++)
+            {
+                string line = lines[index];
+                string lowerCaseLine = line.ToLowerInvariant();
+                bool hasSensitiveKey = lowerCaseLine.Contains("seed") ||
+                                       lowerCaseLine.Contains("secret") ||
+                                       lowerCaseLine.Contains("password") ||
+                                       lowerCaseLine.Contains("pin");
+
+                if (hasSensitiveKey)
+                {
+                    int separatorIndex = line.IndexOf(':');
+                    if (separatorIndex >= 0)
+                    {
+                        lines[index] = line.Substring(0, separatorIndex + 1) + " ********";
+                    }
+                    else
+                    {
+                        lines[index] = "********";
+                    }
+                }
+            }
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private static string GetFriendlyExitText(int exitCode)
+        {
+            switch (exitCode)
+            {
+                case 20:
+                    return "The user is blacklisted.";
+                case 21:
+                    return "The user does not exist.";
+                case 22:
+                    return "The user already exists.";
+                case 23:
+                    return "The token algorithm is invalid.";
+                case 24:
+                    return "The user or token is locked.";
+                case 25:
+                    return "The user is delayed.";
+                case 26:
+                    return "The token was reused.";
+                case 27:
+                    return "Token synchronization failed.";
+                case 30:
+                    return "A required parameter is missing.";
+                case 38:
+                    return "The user is disabled.";
+                case 39:
+                    return "The operation was cancelled.";
+                default:
+                    return "Exit code " + exitCode + ".";
+            }
+        }
+
+        private static string GetSafeExceptionMessage(Exception exception)
+        {
+            if (exception is TimeoutException)
+            {
+                return "The operation timed out.";
+            }
+
+            if (exception is OperationCanceledException)
+            {
+                return "The operation was canceled.";
+            }
+
+            if (exception is ArgumentException)
+            {
+                return exception.Message;
+            }
+
+            return "The operation failed. " + exception.GetType().Name + ".";
+        }
+    }
+}

--- a/MultiOtpManager/MultiOtpManager.csproj
+++ b/MultiOtpManager/MultiOtpManager.csproj
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{93b26f9e-8a0e-4f66-9ec1-77c1a96efca2}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>MultiOtpManager</RootNamespace>
+    <AssemblyName>MultiOtpManager</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Core\CredentialProviderRegistryService.cs" />
+    <Compile Include="Core\MultiOtpCliClient.cs" />
+    <Compile Include="Core\MultiOtpProcessExecutor.cs" />
+    <Compile Include="Core\UserModels.cs" />
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="app.manifest" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/MultiOtpManager/Properties/AssemblyInfo.cs
+++ b/MultiOtpManager/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+[assembly: AssemblyTitle("multiOTP Manager")]
+[assembly: AssemblyDescription("Desktop management client for multiOTP")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]

--- a/MultiOtpManager/README.md
+++ b/MultiOtpManager/README.md
@@ -1,0 +1,28 @@
+# multiOTP Manager MVP
+
+This is a WPF management client for the credential-provider build. It targets **.NET Framework 4.5.2** and has no NuGet or third-party UI dependencies.
+
+## Build and deployment
+
+1. Open `MultiOtpManager.csproj` in Visual Studio with the **.NET Framework 4.5.2 targeting pack** installed.
+2. Build `AnyCPU`.
+3. Place `MultiOtpManager.exe` and its manifest in the same directory as the full `multiotp.exe` runtime tree. At runtime the program resolves the executable with:
+
+```csharp
+Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "multiotp.exe")
+```
+
+The manifest requests `requireAdministrator`, because changing credential-provider registry values requires elevation. It declares Windows 7 and later as supported operating systems.
+
+## MVP functions
+
+- Authentication test: bundled multiOTP 5.10.2.2 uses the default check syntax `multiotp.exe username otp`. `MultiOtpCliClient.UseVerifySwitch` can be set to `true` for a CLI build that accepts `-verify username otp`.
+- Users: `multiotp.exe -userslist`
+- User details: `multiotp.exe -user-info username`
+- Credential Provider settings: `cpus_logon`, `cpus_unlock`, and `two_step_hide_otp`
+
+When these registry values are absent, the GUI follows the installer's `3d` default (no active multiOTP prompt for that usage scenario) rather than silently enabling 2FA.
+
+Commands are assembled from typed argument lists and escaped with the Windows quoting rules in `MultiOtpProcessExecutor.EscapeArgument`. User-controlled text is never inserted directly into the command line. Standard output and error are decoded as UTF-8, and every CLI call supports cancellation and a configurable timeout.
+
+No local log file is written. Sensitive detail keys such as seed, PIN, password, and secret are masked in the UI.

--- a/MultiOtpManager/app.manifest
+++ b/MultiOtpManager/app.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <assemblyIdentity version="1.0.0.0" name="MultiOtpManager.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 10 and later -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</asmv1:assembly>


### PR DESCRIPTION
## Summary
- Add a GitHub Actions Windows build matrix for x64 and x86 credential-provider builds and MSI packages
- Add a dependency-free WPF management client targeting .NET Framework 4.5.2
- Support authentication testing, user list/details, and credential-provider registry settings
- Keep CLI invocation asynchronous with cancellation, timeout, UTF-8 decoding, and Windows-safe argument escaping

## Testing
- GitHub Actions run: https://github.com/netoyou/multiOTPCredentialProvider/actions/runs/32969734227
- Credential Provider x64 build passed
- Credential Provider x86 build passed
- WPF manager .NET Framework 4.5.2 build passed